### PR TITLE
fix(common-settings-bridge): clear lint and harden message validation

### DIFF
--- a/packages/common-settings-bridge/src/bridge.test.ts
+++ b/packages/common-settings-bridge/src/bridge.test.ts
@@ -360,15 +360,12 @@ describe("CommonSettingsBridge", () => {
       await handleMessageFn(buildMessage({ version: Number.NEGATIVE_INFINITY, request_id: "req-2" }));
 
       // First call's `isNewUser` is true, so version defaulted to 1 was persisted.
-      expect(mockSettingsRepo.saveSettings).toHaveBeenNthCalledWith(
-        1,
-        "@user:example.com",
-        expect.any(Object),
-        1,
-        expect.any(Number),
-        "req-123",
-        true,
-      );
+      expect(mockSettingsRepo.saveSettings).toHaveBeenNthCalledWith(1, "@user:example.com", expect.any(Object), {
+        version: 1,
+        timestamp: expect.any(Number),
+        requestId: "req-123",
+        isNewUser: true,
+      });
     });
 
     it("should get user settings from repository", async () => {
@@ -453,14 +450,12 @@ describe("CommonSettingsBridge", () => {
 
       await handleMessageFn(buildMessage());
 
-      expect(mockSettingsRepo.saveSettings).toHaveBeenCalledWith(
-        "@user:example.com",
-        mockPayload,
-        2,
-        1640995200000,
-        "req-123",
-        true,
-      );
+      expect(mockSettingsRepo.saveSettings).toHaveBeenCalledWith("@user:example.com", mockPayload, {
+        version: 2,
+        timestamp: 1640995200000,
+        requestId: "req-123",
+        isNewUser: true,
+      });
     });
 
     it("should save settings for existing user", async () => {
@@ -475,14 +470,12 @@ describe("CommonSettingsBridge", () => {
 
       await handleMessageFn(buildMessage());
 
-      expect(mockSettingsRepo.saveSettings).toHaveBeenCalledWith(
-        "@user:example.com",
-        mockPayload,
-        2,
-        1640995200000,
-        "req-123",
-        false,
-      );
+      expect(mockSettingsRepo.saveSettings).toHaveBeenCalledWith("@user:example.com", mockPayload, {
+        version: 2,
+        timestamp: 1640995200000,
+        requestId: "req-123",
+        isNewUser: false,
+      });
     });
 
     it("should execute orchestration steps in correct order", async () => {

--- a/packages/common-settings-bridge/src/bridge.test.ts
+++ b/packages/common-settings-bridge/src/bridge.test.ts
@@ -1,4 +1,5 @@
 import { RabbitMQClient } from "@linagora/rabbitmq-client";
+import type { SynapseAdminApis } from "@vector-im/matrix-bot-sdk";
 import { Bridge, type Intent } from "matrix-appservice-bridge";
 
 import { Database } from "@twake/db";
@@ -6,8 +7,12 @@ import { Database } from "@twake/db";
 import { CommonSettingsBridge } from "./bridge";
 import { MatrixProfileUpdater } from "./matrix-profile-updater";
 import { SettingsRepository } from "./settings-repository";
-import type { BridgeConfig, ISettingsPayload, StoredUserSettings } from "./types";
+import type { BridgeConfig, ISettingsPayload, StoredUserSettings, UserSettingsTableName } from "./types";
 import { SynapseAdminRetryMode } from "./types";
+
+type MockAdminApis = jest.Mocked<Pick<SynapseAdminApis, "isSelfAdmin" | "upsertUser">>;
+type MockRabbitClient = jest.Mocked<Pick<RabbitMQClient, "init" | "subscribe" | "close">>;
+type MockBridgeInstance = jest.Mocked<Pick<Bridge, "run" | "getBot" | "getIntent">>;
 
 // Mock external dependencies
 jest.mock("./settings-repository");
@@ -18,13 +23,13 @@ jest.mock("@twake/db");
 describe("CommonSettingsBridge", () => {
   let bridge: CommonSettingsBridge;
   let mockConfig: BridgeConfig;
-  let mockBridgeInstance: jest.Mocked<Bridge>;
+  let mockBridgeInstance: MockBridgeInstance;
   let mockIntent: jest.Mocked<Intent>;
-  let mockDatabase: jest.Mocked<Database<any>>;
-  let mockClient: jest.Mocked<RabbitMQClient>;
+  let mockDatabase: jest.Mocked<Database<UserSettingsTableName>>;
+  let mockClient: MockRabbitClient;
   let mockSettingsRepo: jest.Mocked<SettingsRepository>;
   let mockProfileUpdater: jest.Mocked<MatrixProfileUpdater>;
-  let mockAdminApis: any;
+  let mockAdminApis: MockAdminApis;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,7 +61,8 @@ describe("CommonSettingsBridge", () => {
       },
     };
 
-    // Mock database
+    // Mock database. Jest's Mocked<T> isn't structurally compatible with the
+    // raw class, so bridge through `unknown` to convert real -> mock and back.
     mockDatabase = {
       ready: Promise.resolve(),
       get: jest.fn(),
@@ -64,56 +70,41 @@ describe("CommonSettingsBridge", () => {
       update: jest.fn(),
       close: jest.fn(),
       ensureColumns: jest.fn().mockResolvedValue(undefined),
-    } as any;
-    (Database as jest.MockedClass<typeof Database>).mockImplementation(() => mockDatabase);
+    } as unknown as jest.Mocked<Database<UserSettingsTableName>>;
+    (Database as jest.MockedClass<typeof Database>).mockImplementation(
+      () => mockDatabase as unknown as Database<string>,
+    );
 
     // Mock RabbitMQ client
     mockClient = {
       init: jest.fn().mockResolvedValue(undefined),
       subscribe: jest.fn().mockResolvedValue(undefined),
       close: jest.fn().mockResolvedValue(undefined),
-    } as any;
-    (RabbitMQClient as jest.MockedClass<typeof RabbitMQClient>).mockImplementation(() => mockClient);
-
-    // Mock admin APIs
-    mockAdminApis = {
-      isSelfAdmin: jest.fn().mockResolvedValue(true),
-      upsertUser: jest.fn().mockResolvedValue(undefined),
     };
-
-    // Mock Intent
-    mockIntent = {
-      ensureRegistered: jest.fn().mockResolvedValue(undefined),
-      setDisplayName: jest.fn().mockResolvedValue(undefined),
-      setAvatarUrl: jest.fn().mockResolvedValue(undefined),
-      matrixClient: {
-        adminApis: {
-          synapse: mockAdminApis,
-        },
-        uploadContentFromUrl: jest.fn().mockResolvedValue("mxc://example.com/avatar123"),
-      },
-    } as any;
+    (RabbitMQClient as jest.MockedClass<typeof RabbitMQClient>).mockImplementation(
+      () => mockClient as unknown as RabbitMQClient,
+    );
 
     // The Bridge mock is handled by the manual mock in __mocks__
     // Create an instance to access the shared mock methods
-    const tempBridge = new Bridge({} as any);
+    const tempBridge = new Bridge({} as ConstructorParameters<typeof Bridge>[0]);
     mockBridgeInstance = {
-      run: tempBridge.run,
-      getBot: tempBridge.getBot,
-      getIntent: tempBridge.getIntent,
-    } as any;
+      run: tempBridge.run as jest.Mock,
+      getBot: tempBridge.getBot as jest.Mock,
+      getIntent: tempBridge.getIntent as jest.Mock,
+    };
 
     // Get the shared mockIntent from the Bridge's getIntent mock
-    mockIntent = mockBridgeInstance.getIntent() as any;
+    mockIntent = mockBridgeInstance.getIntent() as jest.Mocked<Intent>;
 
     // Update mockAdminApis to reference the mockIntent's admin APIs
-    mockAdminApis = mockIntent.matrixClient.adminApis.synapse;
+    mockAdminApis = mockIntent.matrixClient.adminApis.synapse as unknown as MockAdminApis;
 
     // Mock SettingsRepository
     mockSettingsRepo = {
       getUserSettings: jest.fn(),
       saveSettings: jest.fn(),
-    } as any;
+    } as unknown as jest.Mocked<SettingsRepository>;
     (SettingsRepository as jest.MockedClass<typeof SettingsRepository>).mockImplementation(() => mockSettingsRepo);
 
     // Mock MatrixProfileUpdater
@@ -121,7 +112,7 @@ describe("CommonSettingsBridge", () => {
       processChanges: jest.fn().mockResolvedValue(undefined),
       updateDisplayName: jest.fn().mockResolvedValue(undefined),
       updateAvatar: jest.fn().mockResolvedValue(undefined),
-    } as any;
+    } as unknown as jest.Mocked<MatrixProfileUpdater>;
     (MatrixProfileUpdater as jest.MockedClass<typeof MatrixProfileUpdater>).mockImplementation(
       () => mockProfileUpdater,
     );
@@ -226,8 +217,11 @@ describe("CommonSettingsBridge", () => {
     });
 
     it("should default routingKey to '#' when omitted from config", async () => {
-      const configNoRouting = { ...mockConfig, rabbitmq: { ...mockConfig.rabbitmq, routingKey: undefined } };
-      const newBridge = new CommonSettingsBridge(configNoRouting as unknown as typeof mockConfig);
+      const configNoRouting: BridgeConfig = {
+        ...mockConfig,
+        rabbitmq: { ...mockConfig.rabbitmq, routingKey: undefined },
+      };
+      const newBridge = new CommonSettingsBridge(configNoRouting);
       await newBridge.start();
 
       expect(mockClient.subscribe).toHaveBeenCalledWith("test-exchange", "#", "test-queue", expect.any(Function));
@@ -288,7 +282,9 @@ describe("CommonSettingsBridge", () => {
   });
 
   describe("#handleMessage orchestration", () => {
-    let handleMessageFn: (message: Record<string, unknown>) => Promise<void>;
+    // Typed as `unknown` so we can also pass non-object inputs (null/42/[]) to
+    // exercise the runtime guards at the top of the handler.
+    let handleMessageFn: (message: unknown) => Promise<void>;
     let mockUserSettings: StoredUserSettings | null;
     let mockPayload: ISettingsPayload;
 
@@ -339,9 +335,9 @@ describe("CommonSettingsBridge", () => {
     });
 
     it("should ack-and-drop a non-object payload root", async () => {
-      await expect(handleMessageFn(null as unknown as Record<string, unknown>)).resolves.toBeUndefined();
-      await expect(handleMessageFn(42 as unknown as Record<string, unknown>)).resolves.toBeUndefined();
-      await expect(handleMessageFn([] as unknown as Record<string, unknown>)).resolves.toBeUndefined();
+      await expect(handleMessageFn(null)).resolves.toBeUndefined();
+      await expect(handleMessageFn(42)).resolves.toBeUndefined();
+      await expect(handleMessageFn([])).resolves.toBeUndefined();
       expect(mockSettingsRepo.getUserSettings).not.toHaveBeenCalled();
       expect(mockProfileUpdater.processChanges).not.toHaveBeenCalled();
     });

--- a/packages/common-settings-bridge/src/bridge.test.ts
+++ b/packages/common-settings-bridge/src/bridge.test.ts
@@ -342,6 +342,35 @@ describe("CommonSettingsBridge", () => {
       expect(mockProfileUpdater.processChanges).not.toHaveBeenCalled();
     });
 
+    it("should ack-and-drop a message whose timestamp is not finite", async () => {
+      // `1e1000` round-trips through JSON.parse to Infinity; `typeof Infinity === "number"`.
+      // Without the Number.isFinite guard, formatTimestamp(Infinity) throws inside the info log
+      // and the lib retries → DLQ instead of the intended ack-and-drop.
+      await expect(handleMessageFn(buildMessage({ timestamp: Number.POSITIVE_INFINITY }))).resolves.toBeUndefined();
+      await expect(handleMessageFn(buildMessage({ timestamp: Number.NEGATIVE_INFINITY }))).resolves.toBeUndefined();
+      await expect(handleMessageFn(buildMessage({ timestamp: Number.NaN }))).resolves.toBeUndefined();
+      expect(mockSettingsRepo.getUserSettings).not.toHaveBeenCalled();
+      expect(mockProfileUpdater.processChanges).not.toHaveBeenCalled();
+    });
+
+    it("should default version to 1 when version is not finite", async () => {
+      mockSettingsRepo.getUserSettings.mockResolvedValue(null);
+
+      await handleMessageFn(buildMessage({ version: Number.NaN }));
+      await handleMessageFn(buildMessage({ version: Number.NEGATIVE_INFINITY, request_id: "req-2" }));
+
+      // First call's `isNewUser` is true, so version defaulted to 1 was persisted.
+      expect(mockSettingsRepo.saveSettings).toHaveBeenNthCalledWith(
+        1,
+        "@user:example.com",
+        expect.any(Object),
+        1,
+        expect.any(Number),
+        "req-123",
+        true,
+      );
+    });
+
     it("should get user settings from repository", async () => {
       mockUserSettings = null;
       mockSettingsRepo.getUserSettings.mockResolvedValue(mockUserSettings);

--- a/packages/common-settings-bridge/src/bridge.ts
+++ b/packages/common-settings-bridge/src/bridge.ts
@@ -48,13 +48,15 @@ function validateMessage(message: Record<string, unknown>): ParsedMessage {
   if (typeof requestId !== "string" || requestId.length === 0) {
     throw new MessageParseError("Message missing required request_id field");
   }
+  // `Number.isFinite` rejects NaN/Infinity that `typeof === "number"` lets through.
+  // Infinity would later blow up `new Date(...).toISOString()` and turn ack-drop into a DLQ storm.
   const timestamp = message.timestamp;
-  if (typeof timestamp !== "number") {
+  if (!Number.isFinite(timestamp)) {
     throw new MessageParseError("Message missing required timestamp field");
   }
   const payload = message.payload;
   if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new UserIdNotProvidedError();
+    throw new MessageParseError("Message payload must be a JSON object");
   }
   const matrixId = (payload as Record<string, unknown>).matrix_id;
   if (typeof matrixId !== "string" || matrixId.length === 0) {
@@ -64,8 +66,8 @@ function validateMessage(message: Record<string, unknown>): ParsedMessage {
   const source = message.source;
   return {
     userId: matrixId,
-    version: typeof version === "number" ? version : 1,
-    timestamp,
+    version: Number.isFinite(version) ? (version as number) : 1,
+    timestamp: timestamp as number,
     requestId,
     source: typeof source === "string" ? source : "",
     payload: payload as ISettingsPayload,

--- a/packages/common-settings-bridge/src/bridge.ts
+++ b/packages/common-settings-bridge/src/bridge.ts
@@ -14,7 +14,6 @@ import {
 import { SettingsRepository } from "./settings-repository";
 import {
   type BridgeConfig,
-  type CommonSettingsMessage,
   createLoggerAdapter,
   type ISettingsPayload,
   MessageParseError,
@@ -41,25 +40,35 @@ interface ParsedMessage {
 }
 
 /**
- * Validates a CommonSettingsMessage and extracts required fields.
+ * Validates a raw AMQP message and extracts required fields. Runtime narrowing
+ * is used because the lib hands us `Record<string, unknown>` without schema.
  */
-function validateMessage(message: CommonSettingsMessage): ParsedMessage {
-  if (!message.request_id) {
+function validateMessage(message: Record<string, unknown>): ParsedMessage {
+  const requestId = message.request_id;
+  if (typeof requestId !== "string" || requestId.length === 0) {
     throw new MessageParseError("Message missing required request_id field");
   }
-  if (message.timestamp === undefined || message.timestamp === null) {
+  const timestamp = message.timestamp;
+  if (typeof timestamp !== "number") {
     throw new MessageParseError("Message missing required timestamp field");
   }
-  if (!message.payload?.matrix_id) {
+  const payload = message.payload;
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
     throw new UserIdNotProvidedError();
   }
+  const matrixId = (payload as Record<string, unknown>).matrix_id;
+  if (typeof matrixId !== "string" || matrixId.length === 0) {
+    throw new UserIdNotProvidedError();
+  }
+  const version = message.version;
+  const source = message.source;
   return {
-    userId: message.payload.matrix_id,
-    version: message.version ?? 1,
-    timestamp: message.timestamp,
-    requestId: message.request_id,
-    source: message.source,
-    payload: message.payload,
+    userId: matrixId,
+    version: typeof version === "number" ? version : 1,
+    timestamp,
+    requestId,
+    source: typeof source === "string" ? source : "",
+    payload: payload as ISettingsPayload,
   };
 }
 
@@ -243,7 +252,7 @@ export class CommonSettingsBridge {
 
     let parsed: ParsedMessage;
     try {
-      parsed = validateMessage(message as unknown as CommonSettingsMessage);
+      parsed = validateMessage(message);
     } catch (err) {
       if (err instanceof MessageParseError || err instanceof UserIdNotProvidedError) {
         this.#log.error(`Discarding message: validation failed (${(err as Error).message})`);
@@ -475,7 +484,9 @@ export class CommonSettingsBridge {
         // Roll the connection back so the lib's auto-reconnect loop doesn't
         // keep a zombie session open after start() rejects.
         await this.#client.close().catch((closeErr) => {
-          this.#log.warn(`Error closing client during rollback: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`);
+          this.#log.warn(
+            `Error closing client during rollback: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+          );
         });
         throw subscribeError;
       }

--- a/packages/common-settings-bridge/src/bridge.ts
+++ b/packages/common-settings-bridge/src/bridge.ts
@@ -344,7 +344,12 @@ export class CommonSettingsBridge {
           ...(lastSettings?.payload ?? {}),
           ...payload,
         };
-        await this.#settingsRepository.saveSettings(userId, mergedPayload, version, timestamp, requestId, isNewUser);
+        await this.#settingsRepository.saveSettings(userId, mergedPayload, {
+          version,
+          timestamp,
+          requestId,
+          isNewUser,
+        });
       } catch (error) {
         // DB save failed but profile was updated - log and continue in degraded mode
         const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/common-settings-bridge/src/index.test.ts
+++ b/packages/common-settings-bridge/src/index.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/promise-function-async */
-import type { BridgeConfig } from "./types";
+import type { RabbitMQMessageHandler } from "@linagora/rabbitmq-client";
+
+import type { BridgeConfig, ISettingsPayload } from "./types";
+
+type LoggerWithConfigure = jest.Mock & { configure: jest.Mock };
 
 // Must provide factory functions for mocks used at module load time
 jest.mock("matrix-appservice-bridge", () => {
@@ -9,8 +13,10 @@ jest.mock("matrix-appservice-bridge", () => {
     error: jest.fn(),
     debug: jest.fn(),
   };
-  const MockLogger = jest.fn(() => mockLoggerInstance);
-  (MockLogger as any).configure = jest.fn();
+  const MockLogger: LoggerWithConfigure = Object.assign(
+    jest.fn(() => mockLoggerInstance),
+    { configure: jest.fn() },
+  );
 
   return {
     Bridge: jest.fn(),
@@ -85,12 +91,14 @@ const mockDb = {
 
 const mockClientInit = jest.fn(() => Promise.resolve());
 const mockClientClose = jest.fn(() => Promise.resolve());
-let messageHandler: (message: Record<string, unknown>) => Promise<void>;
+let messageHandler: RabbitMQMessageHandler;
 
-const mockClientSubscribe = jest.fn((_exchange: string, _routingKey: string, _queue: string, handler: any) => {
-  messageHandler = handler;
-  return Promise.resolve();
-});
+const mockClientSubscribe = jest.fn(
+  (_exchange: string, _routingKey: string, _queue: string, handler: RabbitMQMessageHandler) => {
+    messageHandler = handler;
+    return Promise.resolve();
+  },
+);
 
 const mockClient = {
   init: mockClientInit,
@@ -130,12 +138,14 @@ beforeEach(() => {
   mockUploadContentFromUrl.mockResolvedValue("mxc://example.com/uploaded123");
   mockUploadContent.mockResolvedValue("mxc://example.com/uploaded123");
   // Mock global fetch for avatar downloads
-  global.fetch = jest.fn(() => Promise.resolve(createMockFetchResponse())) as any;
+  global.fetch = jest.fn(() => Promise.resolve(createMockFetchResponse())) as unknown as typeof fetch;
   // Re-bind capture after clearAllMocks
-  mockClientSubscribe.mockImplementation((_exchange: string, _routingKey: string, _queue: string, handler: any) => {
-    messageHandler = handler;
-    return Promise.resolve();
-  });
+  mockClientSubscribe.mockImplementation(
+    (_exchange: string, _routingKey: string, _queue: string, handler: RabbitMQMessageHandler) => {
+      messageHandler = handler;
+      return Promise.resolve();
+    },
+  );
 });
 
 const createTestConfig = (adminRetryMode: "disabled" | "fallback" | "exclusive" = "disabled"): BridgeConfig => ({
@@ -162,7 +172,16 @@ const createTestConfig = (adminRetryMode: "disabled" | "fallback" | "exclusive" 
   },
 });
 
-const createTestMessage = (overrides: Record<string, any> = {}) => ({
+interface TestMessageOverrides {
+  source?: string;
+  nickname?: string;
+  request_id?: string;
+  timestamp?: number;
+  version?: number;
+  payload?: Partial<ISettingsPayload>;
+}
+
+const createTestMessage = (overrides: TestMessageOverrides = {}): Record<string, unknown> => ({
   source: "test-service",
   nickname: "test-user",
   request_id: "12345",
@@ -187,7 +206,7 @@ describe("CommonSettingsBridge - Message Parsing", () => {
   it("should process a valid message", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -204,7 +223,7 @@ describe("CommonSettingsBridge - Message Parsing", () => {
   it("should ack-and-drop messages where matrix_id is missing (no retry storm)", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -223,7 +242,7 @@ describe("CommonSettingsBridge - Avatar URL Resolution", () => {
   it("should use MXC URL directly when avatar starts with mxc://", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -243,7 +262,7 @@ describe("CommonSettingsBridge - Avatar URL Resolution", () => {
   it("should download and upload HTTP avatar URL", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -267,7 +286,7 @@ describe("CommonSettingsBridge - Avatar URL Resolution", () => {
   it("should propagate upload errors", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     mockUploadContent.mockRejectedValueOnce(new Error("Upload failed"));
 
@@ -286,7 +305,7 @@ describe("CommonSettingsBridge - Avatar URL Resolution", () => {
   it("should use uploaded MXC URL with admin API in EXCLUSIVE mode", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig("exclusive");
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -315,7 +334,7 @@ describe("CommonSettingsBridge - Matrix Updates", () => {
   it("should use admin API in EXCLUSIVE mode for display name", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig("exclusive");
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -331,7 +350,7 @@ describe("CommonSettingsBridge - Matrix Updates", () => {
   it("should use intent API in DISABLED mode for display name", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig("disabled");
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -344,7 +363,7 @@ describe("CommonSettingsBridge - Matrix Updates", () => {
   it("should fallback to admin API on M_FORBIDDEN in FALLBACK mode", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig("fallback");
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     mockSetDisplayName.mockRejectedValueOnce({
       errcode: "M_FORBIDDEN",
@@ -367,7 +386,7 @@ describe("CommonSettingsBridge - Change Detection", () => {
   it("should not update display name when unchanged", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     const existingSettings = {
       matrix_id: "@user:example.com",
@@ -395,7 +414,7 @@ describe("CommonSettingsBridge - Change Detection", () => {
   it("should update display name when changed", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     const existingSettings = {
       matrix_id: "@user:example.com",
@@ -431,7 +450,7 @@ describe("CommonSettingsBridge - Lifecycle", () => {
   it("should start successfully", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 
@@ -444,7 +463,7 @@ describe("CommonSettingsBridge - Lifecycle", () => {
   it("should stop successfully", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
     await bridge.stop();
@@ -456,7 +475,7 @@ describe("CommonSettingsBridge - Lifecycle", () => {
   it("should check admin privileges on start", async () => {
     const { CommonSettingsBridge } = await import("./index");
     const config = createTestConfig();
-    const bridge = new (CommonSettingsBridge as any)(config);
+    const bridge = new CommonSettingsBridge(config);
 
     await bridge.start();
 

--- a/packages/common-settings-bridge/src/index.ts
+++ b/packages/common-settings-bridge/src/index.ts
@@ -6,7 +6,6 @@
 
 // Re-export main bridge class
 export { CommonSettingsBridge } from "./bridge";
-
 // Re-export types and errors
 export * from "./types";
 
@@ -15,6 +14,7 @@ export * from "./types";
 // =============================================================================
 
 import { AppServiceRegistration, Cli, Logger } from "matrix-appservice-bridge";
+
 import { CommonSettingsBridge } from "./bridge";
 import type { BridgeConfig } from "./types";
 

--- a/packages/common-settings-bridge/src/matrix-profile-updater.test.ts
+++ b/packages/common-settings-bridge/src/matrix-profile-updater.test.ts
@@ -1,12 +1,18 @@
 import type { Intent, Logger } from "matrix-appservice-bridge";
+
 import { type MatrixApis, MatrixProfileUpdater } from "./matrix-profile-updater";
 import { type ISettingsPayload, SynapseAdminRetryMode } from "./types";
+
+type MockMatrixClient = {
+  uploadContentFromUrl: jest.Mock;
+  uploadContent: jest.Mock;
+};
 
 describe("MatrixProfileUpdater", () => {
   let mockApis: jest.Mocked<MatrixApis>;
   let mockIntent: jest.Mocked<Intent>;
   let mockLogger: jest.Mocked<Logger>;
-  let mockMatrixClient: any;
+  let mockMatrixClient: MockMatrixClient;
 
   beforeEach(() => {
     // Create mock matrix client
@@ -20,7 +26,7 @@ describe("MatrixProfileUpdater", () => {
       setDisplayName: jest.fn(),
       setAvatarUrl: jest.fn(),
       matrixClient: mockMatrixClient,
-    } as any;
+    } as unknown as jest.Mocked<Intent>;
 
     // Create mock APIs
     mockApis = {
@@ -35,7 +41,7 @@ describe("MatrixProfileUpdater", () => {
       info: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
-    } as any;
+    } as unknown as jest.Mocked<Logger>;
 
     // Mock global fetch
     global.fetch = jest.fn();

--- a/packages/common-settings-bridge/src/matrix-profile-updater.ts
+++ b/packages/common-settings-bridge/src/matrix-profile-updater.ts
@@ -1,5 +1,22 @@
 import type { Intent, Logger } from "matrix-appservice-bridge";
+
 import { AvatarFetchError, type ISettingsPayload, SynapseAdminRetryMode } from "./types";
+
+/**
+ * Shape of errors raised by the Matrix client/admin APIs. They are plain Error
+ * instances with an optional `errcode` (M_FORBIDDEN, M_EXCLUSIVE, ...).
+ */
+interface MatrixError {
+  errcode?: string;
+  message?: string;
+}
+
+function asMatrixError(err: unknown): MatrixError {
+  if (err !== null && typeof err === "object") {
+    return err as MatrixError;
+  }
+  return {};
+}
 
 /**
  * Default maximum allowed avatar file size (5MB).
@@ -93,15 +110,14 @@ export class MatrixProfileUpdater {
       this.logger.debug(`Attempting standard API display name update for ${userId}`);
       await intent.setDisplayName(newDisplayname);
       this.logger.info(`Updated display name for ${userId} to "${newDisplayname}"`);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const mxErr = asMatrixError(err);
       this.logger.warn(
-        `Failed to update display name via standard API for ${userId}: ${
-          err?.errcode || err?.message || "Unknown error"
-        }`,
+        `Failed to update display name via standard API for ${userId}: ${mxErr.errcode || mxErr.message || "Unknown error"}`,
       );
 
       if (
-        (err?.errcode === "M_FORBIDDEN" || err?.errcode === "M_EXCLUSIVE") &&
+        (mxErr.errcode === "M_FORBIDDEN" || mxErr.errcode === "M_EXCLUSIVE") &&
         this.retryMode === SynapseAdminRetryMode.FALLBACK
       ) {
         this.logger.info(`Falling back to admin API for display name ${userId}`);
@@ -236,10 +252,11 @@ export class MatrixProfileUpdater {
       const mxcUrl = await intent.matrixClient.uploadContent(buffer, contentType, "avatar");
       this.logger.info(`Uploaded avatar to Synapse for ${userId}: ${mxcUrl}`);
       return mxcUrl;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const mxErr = asMatrixError(error);
       // In FALLBACK mode, try bot upload on M_FORBIDDEN
       if (
-        (error?.errcode === "M_FORBIDDEN" || error?.errcode === "M_EXCLUSIVE") &&
+        (mxErr.errcode === "M_FORBIDDEN" || mxErr.errcode === "M_EXCLUSIVE") &&
         this.retryMode === SynapseAdminRetryMode.FALLBACK
       ) {
         this.logger.info(`Falling back to bot credentials for avatar upload: ${userId}`);
@@ -280,13 +297,14 @@ export class MatrixProfileUpdater {
       this.logger.debug(`Attempting standard API avatar update for ${userId}`);
       await intent.setAvatarUrl(resolvedUrl);
       this.logger.info(`Updated avatar for ${userId} to "${resolvedUrl}"`);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const mxErr = asMatrixError(err);
       this.logger.warn(
-        `Failed to update avatar via standard API for ${userId}: ${err?.errcode || err?.message || "Unknown error"}`,
+        `Failed to update avatar via standard API for ${userId}: ${mxErr.errcode || mxErr.message || "Unknown error"}`,
       );
 
       if (
-        (err?.errcode === "M_FORBIDDEN" || err?.errcode === "M_EXCLUSIVE") &&
+        (mxErr.errcode === "M_FORBIDDEN" || mxErr.errcode === "M_EXCLUSIVE") &&
         this.retryMode === SynapseAdminRetryMode.FALLBACK
       ) {
         this.logger.info(`Falling back to admin API for avatar ${userId}`);

--- a/packages/common-settings-bridge/src/settings-repository.test.ts
+++ b/packages/common-settings-bridge/src/settings-repository.test.ts
@@ -12,13 +12,19 @@ jest.mock("matrix-appservice-bridge", () => {
     error: jest.fn(),
     debug: jest.fn(),
   };
-  const MockLogger = jest.fn(() => mockLoggerInstance);
-  (MockLogger as any).configure = jest.fn();
+  const MockLogger = Object.assign(
+    jest.fn(() => mockLoggerInstance),
+    { configure: jest.fn() },
+  );
 
   return {
     Logger: MockLogger,
   };
 });
+
+import type { Logger as RealLogger } from "matrix-appservice-bridge";
+
+import type { Database as RealDatabase } from "@twake/db";
 
 import { SettingsRepository } from "./settings-repository";
 
@@ -73,7 +79,10 @@ describe("SettingsRepository", () => {
     jest.clearAllMocks();
     mockDb = createMockDatabase();
     mockLogger = createMockLogger();
-    repository = new SettingsRepository(mockDb as any, mockLogger as any);
+    repository = new SettingsRepository(
+      mockDb as unknown as RealDatabase<UserSettingsTableName>,
+      mockLogger as unknown as RealLogger,
+    );
   });
 
   describe("getUserSettings", () => {
@@ -164,7 +173,7 @@ describe("SettingsRepository", () => {
     it("should insert new settings when isNewUser is true", async () => {
       mockDb.insert.mockResolvedValue(undefined);
 
-      await repository.saveSettings(userId, payload, version, timestamp, requestId, true);
+      await repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: true });
 
       expect(mockDb.insert).toHaveBeenCalledWith("usersettings", {
         matrix_id: userId,
@@ -183,7 +192,7 @@ describe("SettingsRepository", () => {
     it("should update existing settings when isNewUser is false", async () => {
       mockDb.update.mockResolvedValue(undefined);
 
-      await repository.saveSettings(userId, payload, version, timestamp, requestId, false);
+      await repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: false });
 
       expect(mockDb.update).toHaveBeenCalledWith(
         "usersettings",
@@ -207,9 +216,9 @@ describe("SettingsRepository", () => {
       const insertError = new Error("Database connection lost");
       mockDb.insert.mockRejectedValue(insertError);
 
-      await expect(repository.saveSettings(userId, payload, version, timestamp, requestId, true)).rejects.toThrow(
-        "Database connection lost",
-      );
+      await expect(
+        repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: true }),
+      ).rejects.toThrow("Database connection lost");
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(`Failed to insert cache entry for ${userId}: Database connection lost`),
@@ -221,7 +230,7 @@ describe("SettingsRepository", () => {
       mockDb.insert.mockRejectedValue(duplicateError);
       mockDb.update.mockResolvedValue(undefined);
 
-      await repository.saveSettings(userId, payload, version, timestamp, requestId, true);
+      await repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: true });
 
       expect(mockDb.insert).toHaveBeenCalledWith("usersettings", {
         matrix_id: userId,
@@ -247,12 +256,11 @@ describe("SettingsRepository", () => {
     });
 
     it("should fallback to update when insert fails with PostgreSQL unique violation code", async () => {
-      const duplicateError: any = new Error("unique constraint violation");
-      duplicateError.code = "23505";
+      const duplicateError = Object.assign(new Error("unique constraint violation"), { code: "23505" });
       mockDb.insert.mockRejectedValue(duplicateError);
       mockDb.update.mockResolvedValue(undefined);
 
-      await repository.saveSettings(userId, payload, version, timestamp, requestId, true);
+      await repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: true });
 
       expect(mockDb.update).toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining("concurrent insert detected"));
@@ -262,9 +270,9 @@ describe("SettingsRepository", () => {
       const updateError = new Error("Update failed");
       mockDb.update.mockRejectedValue(updateError);
 
-      await expect(repository.saveSettings(userId, payload, version, timestamp, requestId, false)).rejects.toThrow(
-        "Update failed",
-      );
+      await expect(
+        repository.saveSettings(userId, payload, { version, timestamp, requestId, isNewUser: false }),
+      ).rejects.toThrow("Update failed");
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining(`Failed to update cache entry for ${userId}: Update failed`),
@@ -278,7 +286,7 @@ describe("SettingsRepository", () => {
         display_name: 'User with "quotes" and special chars: \n\t',
       });
 
-      await repository.saveSettings(userId, complexPayload, version, timestamp, requestId, true);
+      await repository.saveSettings(userId, complexPayload, { version, timestamp, requestId, isNewUser: true });
 
       expect(mockDb.insert).toHaveBeenCalledWith("usersettings", {
         matrix_id: userId,

--- a/packages/common-settings-bridge/src/settings-repository.ts
+++ b/packages/common-settings-bridge/src/settings-repository.ts
@@ -1,6 +1,19 @@
-import type { Database, DbGetResult } from "@twake/db";
 import type { Logger } from "matrix-appservice-bridge";
+
+import type { Database, DbGetResult } from "@twake/db";
+
 import type { ISettingsPayload, StoredUserSettings, UserSettingsTableName } from "./types";
+
+/**
+ * Metadata accompanying a settings save: version, timestamp, request id, and
+ * whether to insert (new user) or update (existing user).
+ */
+export interface SaveSettingsMeta {
+  readonly version: number;
+  readonly timestamp: number;
+  readonly requestId: string;
+  readonly isNewUser: boolean;
+}
 
 /**
  * Formats a Unix timestamp (milliseconds) as an ISO 8601 string.
@@ -227,20 +240,11 @@ export class SettingsRepository {
    *
    * @param userId - The Matrix user ID
    * @param payload - The settings payload to persist
-   * @param version - The version number of the settings
-   * @param timestamp - The timestamp when settings were last modified
-   * @param requestId - The unique request ID for idempotency tracking
-   * @param isNewUser - Whether this is a new user (insert) or existing user (update)
+   * @param meta - Versioning, timestamp, request id, and whether this is an insert vs update
    * @throws Error if database operation fails
    */
-  async saveSettings(
-    userId: string,
-    payload: ISettingsPayload,
-    version: number,
-    timestamp: number,
-    requestId: string,
-    isNewUser: boolean,
-  ): Promise<void> {
+  async saveSettings(userId: string, payload: ISettingsPayload, meta: SaveSettingsMeta): Promise<void> {
+    const { version, timestamp, requestId, isNewUser } = meta;
     const cacheData = {
       matrix_id: userId,
       settings: JSON.stringify(payload),
@@ -257,7 +261,10 @@ export class SettingsRepository {
       } catch (error) {
         // Handle TOCTOU race: another request may have inserted first
         const errorMsg = error instanceof Error ? error.message.toLowerCase() : "";
-        const errorCode = (error as any)?.code;
+        const errorCode =
+          error !== null && typeof error === "object" && "code" in error
+            ? (error as { code?: unknown }).code
+            : undefined;
         const isDuplicateKey =
           errorMsg.includes("duplicate") ||
           errorMsg.includes("unique") ||


### PR DESCRIPTION
## Summary

The whole `packages/common-settings-bridge` package now passes `biome ci` cleanly. #367 merged with a "we'll clean it up later" compromise; this is the cleanup. Along the way, replacing the `as any` casts in the message handler with real runtime narrowing uncovered two latent bugs that the type-erasure had been hiding.

The handler typed timestamp and version as numbers but relied on a falsy/null check, so any JSON producer could send `1e1000` (parses to `Infinity`) and slip past validation. An `Infinity` timestamp then crashed `new Date(...).toISOString()` inside the info log, escaped the validation try/catch, and turned the intended ack-and-drop into a retry-then-DLQ storm. A non-finite version made every comparison in `shouldApplyUpdate` return false and silently discarded legitimate updates as "stale". Both guards now use `Number.isFinite`.

Also splits the "payload is not an object" case out of `UserIdNotProvidedError` so the two failure modes show up differently in logs, and refactors `saveSettings` to take a meta object since six positional parameters tripped `useMaxParams`.

The lint CI is still red overall because the rest of the monorepo (apps, other packages) has its own pre-existing errors, but the package this PR touches is clean.