### PR TITLE
chore(tom-server-e2e): pass biome lint

### DIFF
--- a/apps/tom-server-e2e/src/support/global-setup.ts
+++ b/apps/tom-server-e2e/src/support/global-setup.ts
@@ -1,10 +1,13 @@
 import { waitForPortOpen } from "@nx/node/utils";
 
-/* eslint-disable */
-var __TEARDOWN_MESSAGE__: string;
+declare global {
+  // biome-ignore lint/suspicious/noVar: TypeScript requires `var` for global augmentation
+  var __TEARDOWN_MESSAGE__: string;
+}
 
-module.exports = async () => {
-  // Start services that that the app needs to run (e.g. database, docker-compose, etc.).
+module.exports = async (): Promise<void> => {
+  // Start services that the app needs to run (e.g. database, docker-compose, etc.).
+  // biome-ignore lint/suspicious/noConsole: jest global setup logs to the test runner
   console.log("\nSetting up...\n");
 
   const host = process.env.HOST ?? "localhost";

--- a/apps/tom-server-e2e/src/support/global-teardown.ts
+++ b/apps/tom-server-e2e/src/support/global-teardown.ts
@@ -1,11 +1,10 @@
 import { killPort } from "@nx/node/utils";
 
-/* eslint-disable */
-
-module.exports = async () => {
+module.exports = async (): Promise<void> => {
   // Put clean up logic here (e.g. stopping services, docker-compose, etc.).
   // Hint: `globalThis` is shared between setup and teardown.
   const port = process.env.PORT ? Number(process.env.PORT) : 3000;
   await killPort(port);
+  // biome-ignore lint/suspicious/noConsole: jest global teardown logs to the test runner
   console.log(globalThis.__TEARDOWN_MESSAGE__);
 };

--- a/apps/tom-server-e2e/src/support/test-setup.ts
+++ b/apps/tom-server-e2e/src/support/test-setup.ts
@@ -1,7 +1,7 @@
-/* eslint-disable */
 import axios from "axios";
 
-module.exports = async () => {
+// biome-ignore lint/suspicious/useAwait: jest async hook signature; configuration is synchronous
+module.exports = async (): Promise<void> => {
   // Configure axios for tests to use.
   const host = process.env.HOST ?? "localhost";
   const port = process.env.PORT ?? "3000";


### PR DESCRIPTION
## Summary

Replaces the blanket `/* eslint-disable */` in the e2e jest setup/teardown files with targeted `biome-ignore` comments where the rule genuinely doesn't apply (the `var` global augmentation, jest-runner `console.log`s) and adds explicit return types on the `module.exports` async functions.